### PR TITLE
Refactor `ScopedFile` to use `FileMode` enum instead of boolean flags

### DIFF
--- a/src/ScopedFile.cpp
+++ b/src/ScopedFile.cpp
@@ -23,14 +23,14 @@ SOFTWARE.
 */
 #include "ScopedFile.h"
 
-ScopedFile::ScopedFile(const char *filename, bool openToWrite, uint8_t sdPin, uint32_t frequency)
+ScopedFile::ScopedFile(const char *filename, FileMode mode, uint8_t sdPin, uint32_t frequency)
 {
-    open(filename, openToWrite, sdPin,frequency);
+    open(filename, mode, sdPin, frequency);
 }
 
-ScopedFile::ScopedFile(const String &filename, bool openToWrite, uint8_t sdPin, uint32_t frequency)
+ScopedFile::ScopedFile(const String &filename, FileMode mode, uint8_t sdPin, uint32_t frequency)
 {
-    open(filename.c_str(), openToWrite, sdPin,frequency);
+    open(filename.c_str(), mode, sdPin, frequency);
 }
 
 ScopedFile::~ScopedFile()
@@ -52,12 +52,12 @@ bool ScopedFile::isValid() const
     return file_;
 }
 
-void ScopedFile::open(const char *filename, bool openToWrite, uint8_t sdPin, uint32_t frequency)
+void ScopedFile::open(const char *filename, FileMode mode, uint8_t sdPin, uint32_t frequency)
 {
     if (!SD.begin(sdPin, SPI, frequency))
     {
         file_ = File();
         return;
     }
-    file_ = SD.open(filename, openToWrite ? FILE_WRITE : FILE_READ);
+    file_ = SD.open(filename, (mode == FileMode::Write) ? FILE_WRITE : FILE_READ);
 }

--- a/src/ScopedFile.h
+++ b/src/ScopedFile.h
@@ -27,14 +27,19 @@ SOFTWARE.
 #include <Arduino.h>
 #include <SD.h>
 
-#define OPEN_WRITE true
-#define OPEN_READ false
+enum class FileMode
+{
+    Read,
+    Write
+};
 
 class ScopedFile
 {
 public:
-    ScopedFile(const char *filename, bool openToWrite = false, uint8_t sdPin = SS, uint32_t frequency = 4000000);
-    ScopedFile(const String &filename, bool openToWrite = false, uint8_t sdPin = SS, uint32_t frequency = 4000000);
+
+
+    ScopedFile(const char *filename, FileMode mode = FileMode::Read, uint8_t sdPin = SS, uint32_t frequency = 4000000);
+    ScopedFile(const String &filename, FileMode mode = FileMode::Read, uint8_t sdPin = SS, uint32_t frequency = 4000000);
     ~ScopedFile();
 
     File &get();
@@ -47,7 +52,7 @@ public:
 
 private:
     File file_;
-    void open(const char *filename, bool openToWrite, uint8_t sdPin, uint32_t frequency);
+    void open(const char *filename, FileMode mode, uint8_t sdPin, uint32_t frequency);
 };
 
 #endif // SCOPEDFILE_H

--- a/src/httpTask.cpp
+++ b/src/httpTask.cpp
@@ -76,7 +76,7 @@ bool loadMoonSettings(String &result)
 
     std::array<float, NUMBER_OF_CHANNELS> tempMoonLevel;
     {
-        ScopedFile scopedFile(MOON_SETTINGS_FILE, OPEN_READ, SDCARD_SS, 20000000);
+        ScopedFile scopedFile(MOON_SETTINGS_FILE, FileMode::Read, SDCARD_SS, 20000000);
         if (!scopedFile.isValid())
         {
             result = "SD Card mount or file open failed";
@@ -149,7 +149,7 @@ bool saveMoonSettings(String &result)
         return false;
     }
 
-    ScopedFile scopedFile(MOON_SETTINGS_FILE, OPEN_WRITE, SDCARD_SS, 20000000);
+    ScopedFile scopedFile(MOON_SETTINGS_FILE, FileMode::Write, SDCARD_SS, 20000000);
     if (!scopedFile.isValid())
     {
         result = "SD Card mount or file open failed";
@@ -236,7 +236,7 @@ time_t time_diff(struct tm *start, struct tm *end)
 static bool handleFileUpload(const String &data, const String &filePath, String &result)
 {
     
-    ScopedFile scopedFile(filePath, OPEN_WRITE, SDCARD_SS, 20000000);
+    ScopedFile scopedFile(filePath, FileMode::Write, SDCARD_SS, 20000000);
     if (!scopedFile.isValid())
     {
         result = "SD Card mount or file open failed";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,7 +247,7 @@ bool saveDefaultTimers(String &result)
         return false;
     }
 
-    ScopedFile scopedFile(DEFAULT_TIMERFILE, OPEN_WRITE, SDCARD_SS, 20000000);
+    ScopedFile scopedFile(DEFAULT_TIMERFILE, FileMode::Write, SDCARD_SS, 20000000);
     if (!scopedFile.isValid())
     {
         result = "SD Card mount or file open failed";
@@ -294,7 +294,7 @@ bool loadDefaultTimers(String &result)
         return false;
     }
 
-    ScopedFile scopedFile(DEFAULT_TIMERFILE, OPEN_READ, SDCARD_SS, 20000000);
+    ScopedFile scopedFile(DEFAULT_TIMERFILE, FileMode::Read, SDCARD_SS, 20000000);
     if (!scopedFile.isValid())
     {
         result = "SD Card mount or file open failed";


### PR DESCRIPTION
- Introduced `FileMode` enum class with `Read` and `Write` modes